### PR TITLE
Enable mas-cli

### DIFF
--- a/hypergenesis.sh
+++ b/hypergenesis.sh
@@ -9,7 +9,7 @@ set -e
 dotfiles_repo='git@github.com:mattmcmanus/dotfiles.git'
 dotfiles_location="$HOME/.dotfiles"
 
-hypergenesis_file_lists="$dotfiles_location/hypergensis"
+hypergenesis_file_lists="$dotfiles_location/hypergenesis"
 homebrew_taps="$hypergenesis_file_lists/homebrew-taps.txt"
 homebrew_installs="$hypergenesis_file_lists/homebrew-installs.txt"
 homebrew_cask_installs="$hypergenesis_file_lists/homebrew-cask-installs.txt"

--- a/hyperprep.sh
+++ b/hyperprep.sh
@@ -9,6 +9,18 @@ brew ls | grep -v brew-cask > $dotfiles_location/homebrew-installs.txt
 brew cask list > $dotfiles_location/homebrew-cask-installs.txt
 ls -1 /Applications/ > $dotfiles_location/applications-reference.txt
 
+if ! brew ls --versions mas > /dev/null; then
+  read -p "Would you like to install mas-cli to enable re-install of Mac App Store apps? (Y/n): " -n 1 -r
+  echo    
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    brew install mas
+  fi
+fi
+
+if brew ls --versions mas > /dev/null; then
+  mas list > $dotfiles_location/app-store-installs.txt
+fi
 # ls -1 $HOME/.nvm/versions/node/`nvm current`/bin | grep -v node| grep -v npm > $dotfiles_location/npm-global-installs.txt
 
 echo '===================================================================='


### PR DESCRIPTION
Hey Matt - I made some changes to get this working for me, but I saw that you had some work already for this that seems to be in progress, so maybe mine won't make sense.  It's a little funky in that I took out the nicer logging checking/logging for App Store installs that already exist and just let `mas` output it's yellow `Waring: [App] is already installed` which is good enough for me.

And I just added a straight dump of `mas list` to a file in `hyperprep.sh`